### PR TITLE
Keep the original bigram searched

### DIFF
--- a/suggested-content/word-2-vec-service.py
+++ b/suggested-content/word-2-vec-service.py
@@ -16,7 +16,7 @@ logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=lo
 @app.route('/check-phrases', methods=['POST'])
 def check():
     phrases = request.json["phrases"]
-    logging.info('querying phrases %s' %phrases)
+    logging.info('querying phrases %s', phrases)
 
     vector = map(checkProximity, phrases)
     filtered = filter(lambda x: True if x else False, vector)
@@ -47,7 +47,7 @@ def checkProximity(phrase, notwords = None):
     if not notwords:
         try:
             result = __MODEL__.most_similar(positive=phrase)
-            # logging.info("Matches for %s are %s" %(phrase,result))
+            logging.info("Matches for %s are %s", phrase, result)
             return transformResult(result)
         except KeyError:
             return {}


### PR DESCRIPTION
This correlates the original search bigram in the return results so that we can create a link to the original in composer as we need to.

Update sample response below
<img width="412" alt="screen shot 2015-10-29 at 12 01 31" src="https://cloud.githubusercontent.com/assets/1932367/10817866/d98968b8-7e34-11e5-83e2-23e6c6b37e90.png">
