### PR TITLE
Ld downgrade box and deprecate doc2vec

### DIFF
--- a/cloudformation/proposer-suggested-content.json
+++ b/cloudformation/proposer-suggested-content.json
@@ -431,7 +431,7 @@
                                 " || error_exit 'Failed to run cfn-init'\n",
                                 "cd /home/proposer-suggested-content\n",
                                 "tar -xf /home/proposer-suggested-content/proposer-suggested-content.tgz\n",
-                                "python3 suggested-content/word-2-vec-service.py word2vec.bin --doc2vec capi_docs.bin > suggested-content/suggested-content.log"
+                                "python3 suggested-content/word-2-vec-service.py word2vec.bin  > suggested-content/suggested-content.log"
                             ]
                         ]
                     }

--- a/cloudformation/proposer-suggested-content.json
+++ b/cloudformation/proposer-suggested-content.json
@@ -361,30 +361,6 @@
                             "/home/proposer-suggested-content/word2vec.bin": {
                                 "source" : {"Ref": "TrainingSetWordsS3Url"},
                                 "authenticaion": "trainingSetAuthentication"
-                            },
-                            "/home/proposer-suggested-content/sample_docs.bin": {
-                                "source" : {"Ref": "SampleDocsS3Url"},
-                                "authenticaion": "trainingSetAuthentication"
-                            },
-                            "/home/proposer-suggested-content/capi_docs.bin": {
-                                "source" : {"Ref": "Doc2Vec1"},
-                                "authenticaion": "trainingSetAuthentication"
-                            },
-                            "/home/proposer-suggested-content/capi_docs.bin.docvecs.doctag_syn0.npy": {
-                                "source" : {"Ref": "Doc2Vec2"},
-                                "authenticaion": "trainingSetAuthentication"
-                            },
-                            "/home/proposer-suggested-content/capi_docs.bin.docvecs.doctag_syn0norm.npy": {
-                                "source" : {"Ref": "Doc2Vec3"},
-                                "authenticaion": "trainingSetAuthentication"
-                            },
-                            "/home/proposer-suggested-content/capi_docs.bin.syn0.npy": {
-                                "source" : {"Ref": "Doc2Vec4"},
-                                "authenticaion": "trainingSetAuthentication"
-                            },
-                            "/home/proposer-suggested-content/capi_docs.bin.syn1.npy": {
-                                "source" : {"Ref": "Doc2Vec5"},
-                                "authenticaion": "trainingSetAuthentication"
                             }
 
                         }    


### PR DESCRIPTION
If we remove the need to load the doc2vec into memory we can downgrade to a medium. This feature doesn't have heaps of traction so makes sense to downsize

cc @hmgibson23 @philmcmahon 
